### PR TITLE
Change 1.1 test map fix

### DIFF
--- a/include/scenes.h
+++ b/include/scenes.h
@@ -22,7 +22,7 @@ struct kz_scene {
     char          **entrances;
 };
 
-#if Z2_VERSION==NZSJ10
+#if Z2_VERSION==NZSJ10 || Z2_VERSION==NZSJ
 #define CAT_CNT 10
 #else
 #define CAT_CNT 9

--- a/src/scenes.c
+++ b/src/scenes.c
@@ -724,7 +724,7 @@ struct kz_scene_category scene_categories[] = {
     SCENE_CATEGORY_INIT("other",
             91, 18, 17, 89, 95, 88, 10
     ),
-#if Z2_VERSION==NZSJ10
+#if Z2_VERSION==NZSJ10 || Z2_VERSION==NZSJ
     SCENE_CATEGORY_INIT("beta",
             8
     ),


### PR DESCRIPTION
The test map only exists on 1.0 and 1.1 and no other (retail) versions. Doing the check in this way instead of checking that it is not NZSE will be correct even if new MM versions are supported by kz in the future.